### PR TITLE
build: Update build system for relative paths

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,7 +1,6 @@
 # SPDX-License-Identifier: Apache-2.0
 
 cmake_minimum_required(VERSION 3.13.1)
-set(ENV(TVM_INCLUDE_DIRS) "/home/tgall/tvm/tvm/include")
 set(ENV{QEMU_BIN_PATH} "${CMAKE_SOURCE_DIR}/qemu-hack")
 
 set(QEMU_PIPE "\${QEMU_PIPE}")  # QEMU_PIPE is set by the calling TVM instance.
@@ -9,22 +8,21 @@ set(QEMU_PIPE "\${QEMU_PIPE}")  # QEMU_PIPE is set by the calling TVM instance.
 find_package(Zephyr HINTS $ENV{ZEPHYR_BASE})
 project(microtvm_zephyr_runtime)
 
-
 set(CMAKE_VERBOSE_MAKEFILE ON)
 file(GLOB TVM_SOURCES ${CMAKE_SOURCE_DIR}/__tvm*.c)
 target_sources(app PRIVATE src/main.c ${TVM_SOURCES})
 
-#foreach(tvm_lib ${TVM_LIBS})
-#  string(LENGTH ${tvm_lib} tvm_lib_length)
-#  math(EXPR tvm_lib_cut "${tvm_lib_length} - 2")
-#  string(SUBSTRING ${tvm_lib} 3 ${tvm_lib_cut} tvm_lib_name)
-#  add_library(${tvm_lib_name} STATIC IMPORTED)
-#  set_target_properties(${tvm_lib_name} PROPERTIES
-#      IMPORTED_LOCATION ${CMAKE_SOURCE_DIR}/${tvm_lib})
-#  target_link_libraries(app PRIVATE ${tvm_lib_name} libtvm__libutvm_rpc_server.a)
-#endforeach(tvm_lib ${TVM_LIBS})
+target_link_libraries(app
+  PRIVATE
+  ${CMAKE_CURRENT_LIST_DIR}/libtvm__libutvm_rpc_server.a 
+  ${CMAKE_CURRENT_LIST_DIR}/libtvm__libutvm_rpc_common.a 
+  ${CMAKE_CURRENT_LIST_DIR}/libtvm__libcommon.a 
+  ${CMAKE_CURRENT_LIST_DIR}/libtvm__libmodule.a
+  ${CMAKE_CURRENT_LIST_DIR}/libtvm__libsrc.a
+)
 
-target_link_libraries(app PRIVATE /home/tgall/tvm/zephyr-runtime/libtvm__libutvm_rpc_server.a /home/tgall/tvm/zephyr-runtime/libtvm__libutvm_rpc_common.a /home/tgall/tvm/zephyr-runtime/libtvm__libcommon.a /home/tgall/tvm/zephyr-runtime/libtvm__libmodule.a /home/tgall/tvm/zephyr-runtime/libtvm__libsrc.a)
-target_include_directories(app PRIVATE ${TVM_INCLUDE_DIRS})
-target_include_directories(app PRIVATE "/home/tgall/tvm/tvm/include")
-target_include_directories(app PRIVATE "/home/tgall/tvm/zephyr-runtime/crt")
+target_include_directories(app 
+  PRIVATE
+  "${CMAKE_CURRENT_LIST_DIR}/../tvm/include"
+  "${CMAKE_CURRENT_LIST_DIR}/crt"
+)

--- a/README.md
+++ b/README.md
@@ -1,0 +1,30 @@
+# Zephyr uTVM Runtime
+
+This sample application is intended to be used with
+[Zephyr RTOS](https://github.com/zephyrproject-rtos/zephyr), and generates
+a uTVM Runtime binary for supported boards.
+
+## Directory Structure
+
+The application assumes that [TVM](https://github.com/apache/tvm) is located
+one level higher than this sample application. 
+
+You can generate an appropriate file structure via:
+
+```bash
+$ mkdir myproject && cd myproject
+$ git clone https://github.com/apache/tvm.git
+$ git clone https://github.com/tom-gall/zephyr-runtime.git
+```
+
+## Building
+
+Assuming that you have Zephyr previously installed on your system
+([getting started](https://docs.zephyrproject.org/latest/getting_started/index.html)),
+you can build the runtime via some variation of the following:
+
+```bash
+$ source <zephyrpath>/zephyr/zephyr-env.sh
+$ west build -p -b stm32f746g_disco zephyr-runtime/ --
+$ west flash
+```


### PR DESCRIPTION
This commit updates the CMake file to use relative paths,
and adds a README.md file with some basic build instructions.

Signed-off-by: Kevin Townsend <kevin.townsend@linaro.org>